### PR TITLE
Add current ALPS ALPINE engineer experience to About page

### DIFF
--- a/src/data/about.ts
+++ b/src/data/about.ts
@@ -90,6 +90,14 @@ export interface ExperienceItem {
 export const experience: ExperienceItem[] = [
   {
     company: "ALPS ALPINE",
+    role: "Engineer (New Graduate)",
+    period: "Current",
+    logo: "/images/logo-alps.png",
+    description:
+      "Currently working as a new graduate engineer in the Development & Design Division, 4th Software Engineering Department (開発設計部第４ソフト技術部). The team focuses on embedded software development with PoC-style prototyping. I am learning the department's development workflow and strengthening my embedded software engineering fundamentals through daily project work."
+  },
+  {
+    company: "ALPS ALPINE",
     role: "Engineer Internship",
     period: "2 weeks",
     logo: "/images/logo-alps.png",


### PR DESCRIPTION
### Motivation
- Reflect the user's current employment status by adding a new experience entry for ALPS ALPINE. 
- Provide an English-friendly department name while preserving the original Japanese department label for accuracy. 
- Clarify the role focus—embedded software and PoC-style prototyping—and indicate the user is onboarding and learning the team's workflow and embedded development fundamentals. 

### Description
- Added a new top `experience` entry in `src/data/about.ts` for ALPS ALPINE with `role: "Engineer (New Graduate)"` and `period: "Current"`.
- The new entry uses the English rendering "Development & Design Division, 4th Software Engineering Department" and includes the Japanese name `(開発設計部第４ソフト技術部)` in the description.
- The description highlights the team's focus on embedded software PoC-style prototyping and the author’s ongoing learning of department workflow and embedded engineering fundamentals.
- Existing experience entries were left intact and the About data file structure was preserved. 

### Testing
- Ran `npm run build` (Astro static build) which completed successfully without errors. 
- Build output generated the static site routes and reported completion (12 page(s) built).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01eaebf844832e8992ee519e4e4acf)